### PR TITLE
Remove Object Colliders on Pickup

### DIFF
--- a/Assets/Input System/Input Manager.cs
+++ b/Assets/Input System/Input Manager.cs
@@ -28,10 +28,7 @@ public class InputManager : MonoBehaviour
         playerInputActions.Television.CloseTV.performed += CloseTelevision;
 
         playerInputActions.Player.Interact.performed += ObjectInteract;
-        playerInputActions.Player.RotateToggle.performed += ctx => ObjectRotateToggle(ctx.ReadValue<float>()); ;
-
-        //playerInputActions.Player.RotateToggle2.Disable();
-        //playerInputActions.Player.RotateToggle.cancelled += ObjectRotateOff;
+        playerInputActions.Player.RotateToggle.performed += ctx => ObjectInspectionToggle(ctx.ReadValue<float>()); ;
 
         playerInputActions.Player.Rotate.Disable();
     }
@@ -120,69 +117,31 @@ public class InputManager : MonoBehaviour
     private void ObjectRotation()
     {
         Vector2 rotationInput = playerInputActions.Player.Rotate.ReadValue<Vector2>();
-        Transform heldObjectRotation = GetComponentInChildren<Camera>().transform.GetChild(0).gameObject.transform;
-        heldObjectRotation.Rotate(rotationInput.y, rotationInput.x, 0);
+        Inspection inspection = GetComponentInChildren<Inspection>();
+        inspection.RotateObject(rotationInput);
     }
 
-   /* private void ObjectRotateOn(InputAction.CallbackContext context)
+    private void ObjectInspectionToggle(float b)
     {
+        Inspection inspection = GetComponentInChildren<Inspection>();
 
-        *//*bool pressedDown = context.ReadValueAsButton();
-        if (pressedDown) // the key has been pressed
-        {
-            //dothething
-            Debug.Log("Toggling On Rotate");
-            playerInputActions.Player.Look.Disable();
-            playerInputActions.Player.Rotate.Enable();
-        }
-        if (!pressedDown) //the key has been released
-        {
-            //stopdoingthething
-            Debug.Log("Toggling Off Rotate");
-            playerInputActions.Player.Look.Enable();
-            playerInputActions.Player.Rotate.Disable();
-        }*//*
-
-        Debug.Log("Toggling On Rotate");
-        playerInputActions.Player.Look.Disable();
-        playerInputActions.Player.Rotate.Enable();
-        //playerInputActions.Player.RotateToggle.Disable();
-        //playerInputActions.Player.RotateToggle2.Enable();
-    }
-    private void ObjectRotateOff(InputAction.CallbackContext context)
-    {
-    
-        Debug.Log("Toggling Off Rotate");
-        playerInputActions.Player.Look.Enable();
-        playerInputActions.Player.Rotate.Disable();
-        //playerInputActions.Player.RotateToggle2.Disable();
-        //playerInputActions.Player.RotateToggle.Enable();
-    }*/
-
-    private void ObjectRotateToggle(float b)
-    {
-        Transform heldArea = GetComponentInChildren<Camera>().transform.GetChild(0).gameObject.transform;
         if (b > 0)
         {
-            //LMB = true;
             Debug.Log("Toggling On Rotate");
             playerInputActions.Player.Look.Disable();
+            playerInputActions.Player.Move.Disable();
             playerInputActions.Player.Rotate.Enable();
-            Vector3 centerPosition = GetComponentInChildren<Camera>().transform.GetChild(2).gameObject.transform.position;
-            
-            heldArea.transform.position = centerPosition;
+
+            inspection.ToggleFocusObject(true);
         }
         else
         {
-            //LMB = false;
             Debug.Log("Toggling Off Rotate");
             playerInputActions.Player.Look.Enable();
+            playerInputActions.Player.Move.Enable();
             playerInputActions.Player.Rotate.Disable();
-            Vector3 sidePosition = GetComponentInChildren<Camera>().transform.GetChild(1).gameObject.transform.position;
-            
-            heldArea.transform.position = sidePosition;
+            inspection.ToggleFocusObject(false);
         }
     }
-
     #endregion
 }

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,5 +1,88 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1124891998082612597
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7065146330471450527}
+  - component: {fileID: 5606144806059480358}
+  m_Layer: 0
+  m_Name: Inspector Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7065146330471450527
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124891998082612597}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9122481451796719112}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &5606144806059480358
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124891998082612597}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 3
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 8
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!1 &3366239325542754265
 GameObject:
   m_ObjectHideFlags: 0
@@ -64,9 +147,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 7065146330471450527}
   - {fileID: 6042271542983939819}
-  - {fileID: 6928086111706917893}
-  - {fileID: 3308137630757271449}
   m_Father: {fileID: 5965753160802908384}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &4603097404337733328
@@ -108,7 +190,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 55
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -300,37 +382,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!1 &6198532938931210601
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3308137630757271449}
-  m_Layer: 0
-  m_Name: CenterArea
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3308137630757271449
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6198532938931210601}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1.979}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9122481451796719112}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7112840480135186097
 GameObject:
   m_ObjectHideFlags: 0
@@ -459,15 +510,13 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9160489506493272260}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.733, y: -0.281, z: 1.979}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9122481451796719112}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 7112840480135186097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39039b335d6c54e49b18892a6c4ee4b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  holdArea: {fileID: 4672905100457313126}
 --- !u!1001 &6253915638428386019
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -395,6 +395,7 @@ GameObject:
   - component: {fileID: 7165676846656361597}
   - component: {fileID: 4343487692431442849}
   - component: {fileID: 2280167045166944507}
+  - component: {fileID: 259123305166191292}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -488,24 +489,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   holdArea: {fileID: 6042271542983939819}
---- !u!1 &9160489506493272260
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6928086111706917893}
-  m_Layer: 0
-  m_Name: SideArea
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6928086111706917893
-Transform:
+--- !u!114 &259123305166191292
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}

--- a/Assets/Scripts/Object Interaction/Inspection.cs
+++ b/Assets/Scripts/Object Interaction/Inspection.cs
@@ -57,13 +57,13 @@ public class Inspection : MonoBehaviour
     {
         Transform heldObj = holdArea.transform.GetChild(0);
 
-        Collider[] colliders = heldObj.GetComponentsInChildren<Collider>();
-        Bounds bounds = colliders[0].bounds;
+        Renderer[] renderers = heldObj.GetComponentsInChildren<Renderer>();
+        Bounds bounds = renderers[0].bounds;
 
-        for (int i = 1; i < colliders.Length; ++i)
+        for (int i = 1; i < renderers.Length; ++i)
         {
-            bounds.Encapsulate(colliders[i].bounds.min);
-            bounds.Encapsulate(colliders[i].bounds.max);
+            bounds.Encapsulate(renderers[i].bounds.min);
+            bounds.Encapsulate(renderers[i].bounds.max);
         }
 
         heldObjBounds = bounds;
@@ -79,6 +79,12 @@ public class Inspection : MonoBehaviour
         float distFromFace = largestDim / Mathf.Tan(cam.fieldOfView / 2 * Mathf.Deg2Rad);
 
         return distFromFace;
+    }
+
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireCube(heldObjBounds.center, heldObjBounds.size);
     }
 
     public void RotateObject(Vector2 rotationInput)

--- a/Assets/Scripts/Object Interaction/Inspection.cs
+++ b/Assets/Scripts/Object Interaction/Inspection.cs
@@ -1,0 +1,94 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Inspection : MonoBehaviour
+{
+    public GameObject holdArea;
+
+    private Camera cam;
+    private Vector3 screenspaceCenter;
+    private Vector3 localSidePosition;
+
+    private Bounds heldObjBounds;
+
+    private void Awake()
+    {
+        cam = Camera.main;
+        screenspaceCenter = new Vector3(Screen.width / 2, Screen.height / 2, 1.5f);
+        localSidePosition = holdArea.transform.localPosition;
+    }
+
+    public void ToggleFocusObject(bool focus)
+    {
+        Vector3 newPosition;
+        string newLayer;
+
+        if (focus)
+        {
+            screenspaceCenter.z = CalcDistFromFace();
+            Vector3 worldCamCenter = cam.ScreenToWorldPoint(screenspaceCenter);
+            Vector3 offset = holdArea.transform.position - heldObjBounds.center;
+            newPosition = cam.transform.InverseTransformPoint(worldCamCenter + offset);
+
+            newLayer = "Inspection";
+        } else
+        {
+            newPosition = localSidePosition;
+
+            newLayer = "Default";
+        }
+
+        holdArea.transform.localPosition = newPosition;
+        ChangeObjectLayer(holdArea.transform.GetChild(0), newLayer);
+    }
+
+    public void ChangeObjectLayer(Transform obj, string layerName)
+    {
+        obj.gameObject.layer = LayerMask.NameToLayer(layerName);
+
+        foreach (Transform child in obj)
+        {
+            ChangeObjectLayer(child, layerName);
+        }
+    }
+
+    private void GetObjectBounds()
+    {
+        Transform heldObj = holdArea.transform.GetChild(0);
+
+        Collider[] colliders = heldObj.GetComponentsInChildren<Collider>();
+        Bounds bounds = colliders[0].bounds;
+
+        for (int i = 1; i < colliders.Length; ++i)
+        {
+            bounds.Encapsulate(colliders[i].bounds.min);
+            bounds.Encapsulate(colliders[i].bounds.max);
+        }
+
+        heldObjBounds = bounds;
+    }
+
+    private float CalcDistFromFace()
+    {
+        GetObjectBounds();
+
+        float largestDim = Mathf.Max(heldObjBounds.size.x, heldObjBounds.size.y, heldObjBounds.size.z);
+
+        // calculate distance from face depending on object size such that it takes up most of the screen
+        float distFromFace = largestDim / Mathf.Tan(cam.fieldOfView / 2 * Mathf.Deg2Rad);
+
+        return distFromFace;
+    }
+
+    public void RotateObject(Vector2 rotationInput)
+    {
+        if (holdArea.transform.childCount == 0) return;
+
+        GetObjectBounds();
+        Transform heldObjectRotation = holdArea.transform;
+        Vector3 objectCenter = heldObjBounds.center;
+        heldObjectRotation.RotateAround(objectCenter, Vector3.up, rotationInput.x);
+        heldObjectRotation.RotateAround(objectCenter, Vector3.right, rotationInput.y);
+    }
+}

--- a/Assets/Scripts/Object Interaction/Inspection.cs.meta
+++ b/Assets/Scripts/Object Interaction/Inspection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39039b335d6c54e49b18892a6c4ee4b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Object Interaction/PickUpInteractor.cs
+++ b/Assets/Scripts/Object Interaction/PickUpInteractor.cs
@@ -42,11 +42,21 @@ public class PickUpInteractor : MonoBehaviour
         {
             GameObject obj = hit.Value.transform.gameObject;
             PickupObject(obj);
+            ToggleObjectColliders(obj, false);
         }
         else
         {
-            Debug.Log("Drop detected");
+            ToggleObjectColliders(HeldObj, true);
             DropObject();
+        }
+    }
+
+    private void ToggleObjectColliders(GameObject obj, bool on)
+    {        
+        Collider[] colliders = obj.GetComponentsInChildren<Collider>();
+        foreach (Collider collider in colliders)
+        {
+            collider.enabled = on;
         }
     }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -9,7 +9,7 @@ TagManager:
   - Default
   - TransparentFX
   - Ignore Raycast
-  - 
+  - Inspection
   - Water
   - UI
   - 


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The purpose of this was so when the player moves around they are not limited because of the held object, and if they try to inspect/rotate the object it does not bug out.
- Merged in changes from `first-level`
- Removed colliders from object on pickup
- Switched to using renderer bounds rather than collider bounds

### Type of change
<!---  Choose one or more of the following -->
<!---  - Bug fix (non-breaking change which fixes an issue) -->
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->
- Bug fix (non-breaking change which fixes an issue)

# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
