### PR TITLE
Enhance memory teleportation

### DIFF
--- a/Assets/Input System/Input Manager.cs
+++ b/Assets/Input System/Input Manager.cs
@@ -146,6 +146,13 @@ public class InputManager : MonoBehaviour
 
         ChangeCameraPosition cameraCtrl = GetComponentInChildren<ChangeCameraPosition>();
         cameraCtrl.SwitchToTapeView();
+        
+        SceneManagement sceneManagement = FindObjectOfType<SceneManagement>();
+        if (sceneManagement.automaticallyEnterMemorySceneOnOpenTV)
+        {
+            sceneManagement.EnterMemoryScene();
+            sceneManagement.DisableAutomaticEnterMemoryScene();
+        }
     }
 
     public void CloseTelevision(InputAction.CallbackContext obj)
@@ -280,6 +287,9 @@ public class InputManager : MonoBehaviour
 
         playerInputActions.Branching.Disable();
         playerInputActions.Player.Enable();
+        
+        SceneManagement sceneManagement = FindObjectOfType<SceneManagement>();
+        sceneManagement.EnableAutomaticEnterMemoryScene();
     }
     #endregion
 }

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -7279,6 +7279,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 72888871886693321, guid: a2777648e0225374ab93925f2e0653e2, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 771834480956111248, guid: a2777648e0225374ab93925f2e0653e2, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.8191521
@@ -7642,6 +7646,10 @@ PrefabInstance:
     - target: {fileID: 2419354367851444035, guid: 0200db84def1dcc4d9c21569c2c0c54e, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2425047963053950989, guid: 0200db84def1dcc4d9c21569c2c0c54e, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5829734924419995759, guid: 0200db84def1dcc4d9c21569c2c0c54e, type: 3}
       propertyPath: otherBranchingItem

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.45120388, g: 0.50094444, b: 0.5736708, a: 1}
+  m_IndirectSpecularColor: {r: 0.45120293, g: 0.50094366, b: 0.57367015, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2015,6 +2015,11 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 7762675187843565928, guid: 55140f8776d0abf4ba71559713e9a5ef, type: 3}
   m_PrefabInstance: {fileID: 466171566}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &469256041 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4355737878631026977, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
+  m_PrefabInstance: {fileID: 1160039100}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &497996192
 PrefabInstance:
@@ -4253,8 +4258,12 @@ PrefabInstance:
       value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 2017058705551313050, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2017058705551313050, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1.08
+      value: -1.704
       objectReference: {fileID: 0}
     - target: {fileID: 2161561282066356935, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
       propertyPath: m_text
@@ -4345,6 +4354,14 @@ PrefabInstance:
     - target: {fileID: 3936050854869547156, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: SceneManagement, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355737878631026977, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
+      propertyPath: m_Name
+      value: Enter Memory Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 4355737878631026977, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6269223893001667113, guid: 6f6d17ea0fc5344e18e7996364e27cfd, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7502,9 +7519,21 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 845513360825957052, guid: d88c5b4686eb63242bb01bfe2db9a257, type: 3}
+      propertyPath: televisionCanvas
+      value: 
+      objectReference: {fileID: 1058153151}
+    - target: {fileID: 845513360825957052, guid: d88c5b4686eb63242bb01bfe2db9a257, type: 3}
+      propertyPath: enterMemoryButton
+      value: 
+      objectReference: {fileID: 469256041}
+    - target: {fileID: 845513360825957052, guid: d88c5b4686eb63242bb01bfe2db9a257, type: 3}
       propertyPath: memorySceneCanvas
       value: 
       objectReference: {fileID: 1473809546}
+    - target: {fileID: 845513360825957052, guid: d88c5b4686eb63242bb01bfe2db9a257, type: 3}
+      propertyPath: currentBranchingItemModel
+      value: 
+      objectReference: {fileID: 469256041}
     - target: {fileID: 6504859751378464165, guid: d88c5b4686eb63242bb01bfe2db9a257, type: 3}
       propertyPath: firstBranchingObjA
       value: 

--- a/Assets/Scripts/Objects/TapeManager.cs
+++ b/Assets/Scripts/Objects/TapeManager.cs
@@ -55,8 +55,8 @@ public class TapeManager : MonoBehaviour
 
             // TODO: Only activate branching items of this tape if PuzzleManager says we are on this tape's level
             int level = tapeInfo.TapeSO.level;
-            tapeInfo.branchingItemA.GetComponent<ObjectDistanceNew>().enabled = true;
-            tapeInfo.branchingItemB.GetComponent<ObjectDistanceNew>().enabled = true;
+            //tapeInfo.branchingItemA.GetComponent<ObjectDistanceNew>().enabled = true;
+            //tapeInfo.branchingItemB.GetComponent<ObjectDistanceNew>().enabled = true;
             ShowBranchCues();
 
         }

--- a/Assets/Scripts/PuzzleLogic/ObjectDistanceNew.cs
+++ b/Assets/Scripts/PuzzleLogic/ObjectDistanceNew.cs
@@ -35,7 +35,6 @@ public class ObjectDistanceNew : MonoBehaviour
             
             // If object is placed in right location
             if (dist <= distanceThreshold) {
-                Debug.Log("HERE");
                 targetObj.transform.localScale = new Vector3(0, 0, 0);
                 puzzleKeyItem.HandleKeyItemPlaced();
                 objectInPlace = true;

--- a/Assets/Scripts/PuzzleLogic/PuzzleManagerNew.cs
+++ b/Assets/Scripts/PuzzleLogic/PuzzleManagerNew.cs
@@ -10,7 +10,7 @@ public class PuzzleManagerNew : MonoBehaviour
     private int countKeyItemsLeft;
     private VideoControls _videoControls;
     public GameObject currentBranchingItemModel;
-
+    public GameObject enterMemoryButton;
     public GameObject memorySceneCanvas;
     private SceneManagement sceneManagement;
     
@@ -39,6 +39,14 @@ public class PuzzleManagerNew : MonoBehaviour
             _videoControls.ChangeCorruptedVideo(ClipToPlay.BranchBCorrupted);
         }
         memorySceneCanvas.SetActive(true);
+
+        // if first time player placed branching item, show enter memory scene button on TV for future entrances
+        if (level == 1)
+        {
+            sceneManagement.DisableAutomaticEnterMemoryScene();
+            enterMemoryButton.SetActive(true);
+        }
+
         StartCoroutine(waiter());
 
     }

--- a/Assets/Scripts/SceneManagement.cs
+++ b/Assets/Scripts/SceneManagement.cs
@@ -8,19 +8,27 @@ public class SceneManagement : MonoBehaviour
 {
     private InputManager inputManager;
     private TapeManager tapeManager;
+
+    private VideoControls videoControls;
     private PuzzleManagerNew puzzleManager;
+    
     public GameObject effects;
     public GameObject player;
 
     private GameObject camera;
+
+    public bool automaticallyEnterMemorySceneOnOpenTV;
 
     // Start is called before the first frame update
     void Start()
     {
         inputManager = FindObjectOfType<InputManager>();
         tapeManager = FindObjectOfType<TapeManager>();
+        tapeManager = FindObjectOfType<TapeManager>();
+        videoControls = FindObjectOfType<VideoControls>();
         puzzleManager = FindObjectOfType<PuzzleManagerNew>();
         camera = Camera.main.gameObject;
+        automaticallyEnterMemorySceneOnOpenTV = false;
     }
 
     public void EnterMemoryScene()
@@ -60,4 +68,24 @@ public class SceneManagement : MonoBehaviour
         Vector3 cameraRotationAtTelevision = new Vector3(0, 160, 0);
         player.transform.rotation = Quaternion.Euler(cameraRotationAtTelevision);
     }
+
+    public void EnableAutomaticEnterMemoryScene()
+    {
+        // if first time player enters memory scene, automatically teleport them in when they open TV
+        if (puzzleManager.level == 1 && tapeManager.televisionHasTape())
+        {
+            automaticallyEnterMemorySceneOnOpenTV = true;
+            
+            // draw player's attention to TV for the first time after selecting branching object
+            videoControls.televisionParticleEffects.startColor = Color.white;
+            videoControls.televisionParticleEffects.Play();
+            videoControls.televisionAudioSource.Play();
+        }
+    }
+
+    public void DisableAutomaticEnterMemoryScene()
+    {
+        automaticallyEnterMemorySceneOnOpenTV = false;
+    }
+    
 }

--- a/Assets/Scripts/VideoControls.cs
+++ b/Assets/Scripts/VideoControls.cs
@@ -19,8 +19,8 @@ public class VideoControls : MonoBehaviour
     private VideoPlayer _videoPlayer;
     public Image _progressBarImage;
     public GameObject _televisionCanvas;
-    private AudioSource _televisionAudioSource;
-    private ParticleSystem _televisionEffectsOnPuzzleComplete;
+    public AudioSource televisionAudioSource;
+    public ParticleSystem televisionParticleEffects;
     private TapeManager _tapeManager;
 
     void Start()
@@ -29,8 +29,8 @@ public class VideoControls : MonoBehaviour
         _tapeManager = FindObjectOfType<TapeManager>();
         _videoPlayer = GameObject.Find("Video Player").GetComponent<VideoPlayer>();
         _progressBarImage.fillAmount = 0;
-        _televisionAudioSource = GameObject.Find("TV").GetComponent<AudioSource>();
-        _televisionEffectsOnPuzzleComplete = GameObject.Find("TVEffectsPuzzleComplete").GetComponent<ParticleSystem>();
+        televisionAudioSource = GameObject.Find("TV").GetComponent<AudioSource>();
+        televisionParticleEffects = GameObject.Find("TVEffectsPuzzleComplete").GetComponent<ParticleSystem>();
     }
 
     public void PauseOrPlay()
@@ -75,9 +75,9 @@ public class VideoControls : MonoBehaviour
     public void CompletePuzzle(ClipToPlay clip) // TODO: Only call this method if there exists a tape in the TV. Otherwise, we wouldn't know which tape's puzzle we are currently solving
     {   
         // play confirmation noise from television
-        _televisionAudioSource.Play();
-        _televisionEffectsOnPuzzleComplete.startColor = Color.yellow; // play particles from TV
-        _televisionEffectsOnPuzzleComplete.Play();
+        televisionAudioSource.Play();
+        televisionParticleEffects.startColor = Color.yellow; // play particles from TV
+        televisionParticleEffects.Play();
         
         // Set tape to fixed one and play from time the glitch was fixed
         TapeSO tapeSOInTV = _tapeManager.GetCurrentTapeInTV();
@@ -96,9 +96,9 @@ public class VideoControls : MonoBehaviour
     {
         TapeSO tapeSOInTV = _tapeManager.GetCurrentTapeInTV();
         
-        _televisionAudioSource.Play(); // Play noise from TV. TODO: Different noise between this and OnPuzzleComplete
-        _televisionEffectsOnPuzzleComplete.startColor = Color.white; // play particles from TV
-        _televisionEffectsOnPuzzleComplete.Play();
+        televisionAudioSource.Play(); // Play noise from TV. TODO: Different noise between this and OnPuzzleComplete
+        televisionParticleEffects.startColor = Color.white; // play particles from TV
+        televisionParticleEffects.Play();
         
         if (clip == ClipToPlay.OriginalCorrupted) // switch video on TV to original corrupted
         {


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Hide memory scene button until returning from branching item placement
- When branching item is selected, have the TV make a reaction (noise, visuals), and when the player opens TV they get teleported

### Type of change
<!---  Choose one or more of the following -->
<!---  - Bug fix (non-breaking change which fixes an issue) -->
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->
Breaking Change

## How to Integrate
<!--- List any important details that someone would need to know when merging your changes onto the main scene. For example, which prefabs/components to put where -->
This is already integrated into main on this branch. Prefabs have been updated.

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
- Upon startup, pick up posters and select an option. Nothing should happen because there is no tape in the TV.
- Insert a tape into the TV. Open the TV and confirm there is no “Enter Memory” button
- Pick up posters and select an option again. Particles should emit from the TV to draw the player to it. 
- Open the TV and you should be automatically teleported to the memory scene.
- Place the poster in the wrong spot. Nothing should happen
- Place the poster in the right spot, it should highlight and you should see “tape rewriting in progress” with  VHS background overlaid. You should be immediately TP’ed back in front of the TV. The TV should have particles emitting from it. Confirm the correct branching clip is playing from the TV. Confirm you can now see and use the Enter Memory button on the TV
- Enter the memory scene and confirm you see the 3 shadow cues on.
- Exit memory scene via TAB on keyboard or ButtonEast on controller
- Place the 3 key items in the correct spot by transporting each into the memory scene. After the third is in place, you should be transported out in front of the TV. TV should play particles and have correct solution clip playing

# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [ ] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
