### PR TITLE
Fix poster not triggering puzzle target bug

### DIFF
--- a/Assets/Scripts/Objects/TapeManager.cs
+++ b/Assets/Scripts/Objects/TapeManager.cs
@@ -54,8 +54,6 @@ public class TapeManager : MonoBehaviour
             
             TapeInformation tapeInfo = currentTapeInTv.GetComponent<TapeInformation>();
             
-            Debug.Log(tapeInfo.TapeSO.clipToPlay);
-            
             // If user has not placed a branching item down for the current tape in TV, enable branching items' object distance scripts
             if (tapeInfo.TapeSO.clipToPlay == ClipToPlay.OriginalCorrupted)
             {

--- a/Assets/Scripts/Objects/TapeManager.cs
+++ b/Assets/Scripts/Objects/TapeManager.cs
@@ -51,8 +51,18 @@ public class TapeManager : MonoBehaviour
             currentTapeInTv = tapeGameObject;
             tapeGameObject.active = false;
             pickUpInteractor.DropHeldObject();
-
-            ShowBranchCues();
+            
+            TapeInformation tapeInfo = currentTapeInTv.GetComponent<TapeInformation>();
+            
+            Debug.Log(tapeInfo.TapeSO.clipToPlay);
+            
+            // If user has not placed a branching item down for the current tape in TV, enable branching items' object distance scripts
+            if (tapeInfo.TapeSO.clipToPlay == ClipToPlay.OriginalCorrupted)
+            {
+                tapeInfo.branchingItemA.GetComponent<ObjectDistance>().enabled = true;
+                tapeInfo.branchingItemB.GetComponent<ObjectDistance>().enabled = true;
+                ShowBranchCues();
+            }
 
             // After insert tape change to normal lighting
             RenderSettings.ambientMode = AmbientMode.Skybox;
@@ -64,7 +74,6 @@ public class TapeManager : MonoBehaviour
                 GameObject.Find("TVRoomSpotLight").GetComponent<Light>().enabled = true;
                 GameObject.Find("TVRoomSpotLight2").GetComponent<Light>().enabled = true;
                 GameObject.Find("Lamplight").GetComponent<Light>().enabled = true;
-
 
                 lightsAreOn = true;
             }

--- a/Assets/Scripts/PuzzleLogic/PuzzleManager.cs
+++ b/Assets/Scripts/PuzzleLogic/PuzzleManager.cs
@@ -106,10 +106,6 @@ public class PuzzleManager : MonoBehaviour
         // Turn on branching objects for this level
         tapeInformation.branchingItemA.gameObject.SetActive(true);
         tapeInformation.branchingItemB.gameObject.SetActive(true);
-        
-        // Turn on ObjectDistance scripts for branching items
-        tapeInformation.branchingItemA.gameObject.GetComponent<ObjectDistance>().enabled = true;
-        tapeInformation.branchingItemB.gameObject.GetComponent<ObjectDistance>().enabled = true;
 
         // Show physical tape for next level in scene
         tapeObjs[level - 1].SetActive(true);


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->
When posters were placed on correct puzzle target after tape has been removed from TV and reinserted, it did not trigger correctly being placed in the puzzle target due to the posters' object distance scripts being turned off when the tape was removed from TV. This PR fixes this bug.

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Type of change
<!---  Choose one or more of the following -->
<!---  - Bug fix (non-breaking change which fixes an issue) -->
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->
Bug Fix
## How to Integrate
<!--- List any important details that someone would need to know when merging your changes onto the main scene. For example, which prefabs/components to put where -->
Script changes only. 
# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Put the tape into the TV. Take it out and reinsert it a few times. Put the poster in the correct location in the memory. It should now trigger correct placement.

# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
