### PR TITLE
Hide player model in TV mode

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -896,6 +896,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pauseMenu: {fileID: 0}
+  resumeButton: {fileID: 0}
 --- !u!114 &4343487692431442849
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -978,6 +979,7 @@ MonoBehaviour:
   _televisionCanvas: {fileID: 0}
   tvViewCamera: {fileID: 0}
   HUD: {fileID: 0}
+  _playerModel: {fileID: 3366239325542754265}
 --- !u!1001 &4806932000241162068
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ChangeCameraPosition.cs
+++ b/Assets/Scripts/ChangeCameraPosition.cs
@@ -13,6 +13,7 @@ public class ChangeCameraPosition : MonoBehaviour
     public GameObject HUD;
 
     private VideoControls _videoControls;
+    [SerializeField] private GameObject _playerModel;
 
     void Start()
     {        
@@ -29,15 +30,12 @@ public class ChangeCameraPosition : MonoBehaviour
 
     /*
      * If:
-     *    TODO: player within range of TV and
      *    camera is currently on player and
      *    player presses button T
      * then switch camera to focus on TV
      */
     public void SwitchToTapeView()
     {
-        Debug.Log("Switching to tape view");
-
         _originalCamera = Camera.main;
 
         _originalCamera.gameObject.SetActive(false);
@@ -47,6 +45,10 @@ public class ChangeCameraPosition : MonoBehaviour
 
         _televisionCanvas.SetActive(true);
         _videoControls = FindObjectOfType<VideoControls>();
+        
+        // Turn off Player model to avoid blocking TV screen
+        _playerModel.SetActive(false);
+        
     }
     
     /*
@@ -58,8 +60,6 @@ public class ChangeCameraPosition : MonoBehaviour
 
     public void SwitchToPlayerView()
     {
-        Debug.Log("Switching to player view");
-
         _videoControls.Pause(); // pause video in case playing
 
         _originalCamera.gameObject.SetActive(true);
@@ -68,6 +68,9 @@ public class ChangeCameraPosition : MonoBehaviour
         HUD.GetComponent<Canvas>().worldCamera = _originalCamera.transform.Find("UI Camera").GetComponent<Camera>();
 
         _televisionCanvas.SetActive(false);
+        
+        // Turn Player model back on
+        _playerModel.SetActive(true);
     }
 
     void PauseGame()


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->
If the player is too close to the TV screen when they open TV mode, the player model is still visible and blocks the screen. This PR turns the model off when opening TV mode, and back on when exiting TV mode.

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Type of change
<!---  Choose one or more of the following -->
<!---  - Bug fix (non-breaking change which fixes an issue) -->
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->
Bug Fix
## How to Integrate
<!--- List any important details that someone would need to know when merging your changes onto the main scene. For example, which prefabs/components to put where -->
Only player prefab and script have been changed.
# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
- Go right up against the TV screen and open TV mode. Confirm you cannot see the player model anymore.
- Exit TV mode and confirm you can still see the player model (look down at your body). Also confirm the collider is turned back on by colliding into things(such as the stool).
# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
