### PR TITLE
Disable Interactions Until LightsON

### DIFF
--- a/Assets/Prefabs/Props/Key Props/Tape Variant.prefab
+++ b/Assets/Prefabs/Props/Key Props/Tape Variant.prefab
@@ -25,6 +25,10 @@ PrefabInstance:
       value: Tape Variant
       objectReference: {fileID: 0}
     - target: {fileID: 3636712027421575462, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
+      propertyPath: isInteractable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636712027421575462, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: inspectionObjectText
       value: Wonder where this came from? I think it goes into the TV?
       objectReference: {fileID: 0}
@@ -42,15 +46,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.285
+      value: 6.12
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.329
+      value: 2.14
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -11.161
+      value: -17.81
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalRotation.w
@@ -58,15 +62,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6114742089837502924, guid: 1676c170746d9f14e8f4ac131ad7d1c6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -12556,14 +12556,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 858339499}
     m_Modifications:
-    - target: {fileID: 3004229588434310234, guid: 8d5ce930cd4d7a9479e70bfb101dd82d, type: 3}
-      propertyPath: dialogueAudio
-      value: 
-      objectReference: {fileID: 8300000, guid: 8c2c67088118629408f8d5ff7101c584, type: 3}
-    - target: {fileID: 3004229588434310234, guid: 8d5ce930cd4d7a9479e70bfb101dd82d, type: 3}
-      propertyPath: objectAudioInfo
-      value: 
-      objectReference: {fileID: 11400000, guid: 17f168b25b2884e458ef6822baebc095, type: 2}
     - target: {fileID: 4066332758468689076, guid: 8d5ce930cd4d7a9479e70bfb101dd82d, type: 3}
       propertyPath: m_Name
       value: Tape

--- a/Assets/Scripts/Object Interaction/Interactable.cs
+++ b/Assets/Scripts/Object Interaction/Interactable.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+[RequireComponent(typeof(Outline))]
+public class Interactable : MonoBehaviour
+{
+    [Header("Object Interaction")]
+    [SerializeField] public bool isInteractable = false;
+
+    [Header("Sound effects")]
+    [SerializeField] private AudioClip enterSound;
+    [SerializeField] private AudioClip exitSound;
+    [SerializeField] private AudioSource audioSource;
+
+    protected void Awake()
+    {
+        TapeManager.OnFirstTapeInserted += EnableInteraction;
+    }
+
+    protected void OnDestroy()
+    {
+        TapeManager.OnFirstTapeInserted -= EnableInteraction;
+    }
+
+    protected void EnableInteraction()
+    {
+        isInteractable = true;
+    }
+}

--- a/Assets/Scripts/Object Interaction/Interactable.cs.meta
+++ b/Assets/Scripts/Object Interaction/Interactable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ca0f52c34c710741b91646163d0177a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Object Interaction/InteractableDetector.cs
+++ b/Assets/Scripts/Object Interaction/InteractableDetector.cs
@@ -145,19 +145,29 @@ public class InteractableDetector : MonoBehaviour
             }
             interactionType = InteractionType.InsertRemoveTape;
         }
-        else if (hit.transform.GetComponent<PickupInteractable>() && !pickUpInteractor.isHoldingObj())
-        {
-            _interactionCue.SetInteractionCue(InteractionCueType.Pickup);
-            interactionType = InteractionType.Pickup;
-        }
         else if (pickUpInteractor.isHoldingObj())
         {
             interactionType = InteractionType.Place;
-        } else if (hit.transform.GetComponent<OpenInteractable>())
+        }
+        else if (hit.transform.GetComponent<Interactable>()?.isInteractable ?? false)
         {
-            bool isOpen = hit.transform.GetComponent<OpenInteractable>().isOpen;
-            _interactionCue.ToggleOpenClose(isOpen); // TODO: change to open
-            interactionType = InteractionType.Open;
+            Interactable interactable = hit.transform.GetComponent<Interactable>();
+
+            switch (interactable)
+            {
+                case OpenInteractable openInteractable:
+                    bool isOpen = hit.transform.GetComponent<OpenInteractable>().isOpen;
+                    _interactionCue.ToggleOpenClose(isOpen); // TODO: change to open
+                    interactionType = InteractionType.Open;
+                    break;
+                case PickupInteractable pickupInteractable when !pickUpInteractor.isHoldingObj():
+                    _interactionCue.SetInteractionCue(InteractionCueType.Pickup);
+                    interactionType = InteractionType.Pickup;
+                    break;
+                default:
+                    break;
+            }
+
         }
         else
         {

--- a/Assets/Scripts/Object Interaction/OpenInteractable.cs
+++ b/Assets/Scripts/Object Interaction/OpenInteractable.cs
@@ -3,20 +3,14 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[RequireComponent(typeof(Rigidbody))]
-[RequireComponent(typeof(Outline))]
-public class OpenInteractable : MonoBehaviour
+public class OpenInteractable : Interactable
 {
-    [Header("Sound effects")]
-    public AudioClip openSound;
-    public AudioClip closeSound;
-    public AudioSource audioSource;
-
     private Animator animator;
     public bool isOpen = false;
 
-    private void Awake()
+    void Awake()
     {
+        base.Awake();
         animator = GetComponentInParent<Animator>();
     }
 

--- a/Assets/Scripts/Object Interaction/PickupInteractable.cs
+++ b/Assets/Scripts/Object Interaction/PickupInteractable.cs
@@ -5,27 +5,32 @@ using UnityEngine;
 /// <summary>
 /// Contains the functions for modifying the object as well as managing its placement guide
 /// </summary>
-[RequireComponent(typeof(Rigidbody))]
-public class PickupInteractable : MonoBehaviour
+public class PickupInteractable : Interactable
 {
+    [Header("Pickup/Place Sound Effects")]
+    // TODO: change this to use enterSound and exitSound
+    // Use FormerlySerializedAs to keep the old names for the sound effects
+    public AudioSource pickupSound;
+    public AudioSource placeSound;
+
+    [Header("Placement")]
     [SerializeField] private GameObject placementGuide = null;
     [SerializeField] private bool wallMountable = false;
 
-    public Transform originalParent;
+    private Transform originalParent;
     private Vector3 originalObjScale;
     private Rigidbody rigidbody;
     private bool onWall;
 
+    [Header("Inspection Dialogue")]
     public StringValue objectTextInfo;
     public AudioClipScriptableObject objectAudioInfo;
     public string inspectionObjectText;
     public AudioClip dialogueAudio;
 
-    public AudioSource pickupSound;
-    public AudioSource placeSound;
-
     void Awake()
     {
+        base.Awake();
         originalParent = transform.parent;
         originalObjScale = transform.localScale;
         rigidbody = GetComponent<Rigidbody>();

--- a/Assets/Scripts/Objects/TapeManager.cs
+++ b/Assets/Scripts/Objects/TapeManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Video;
 using UnityEngine.Rendering;
+using System;
 
 public class TapeManager : MonoBehaviour
 {
@@ -10,6 +11,8 @@ public class TapeManager : MonoBehaviour
     private GameObject currentTapeInTv;
     private PickUpInteractor pickUpInteractor;
     private bool lightsAreOn;
+
+    public static Action OnFirstTapeInserted;
 
     void Start()
     {
@@ -74,6 +77,7 @@ public class TapeManager : MonoBehaviour
                 GameObject.Find("Lamplight").GetComponent<Light>().enabled = true;
 
                 lightsAreOn = true;
+                OnFirstTapeInserted?.Invoke();
             }
             //GameObject.Find("TV Player").GetComponent<MeshRenderer>().material.DisableKeyword("_EMISSION");
         }


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Added event that is invoked when the lights turn on
- Created parent class Interactable for all pickup and open interactable components
- Refactored interactable detector to only work if the component isInteractable
- Enabled tape from the start

## How to Integrate
<!--- List any important details that someone would need to know when merging your changes onto the main scene. For example, which prefabs/components to put where -->
Mainly scripts were changed

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Load Main. You shouldnt be able to interact with anything other than the tapes. When you insert the tape you should be able to interact with other objects.

# Checklists
## Integration Checklist
- [ ] I have attached this PR to the relevant Trello card
- [ ] **I have not touched the main Room scene**
- [ ] My changes generate no new errors
- [ ] Any dependencies have already gone live on the `main` branch or were merged in separately
- [ ] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [ ] I have requested a review from at least one (1) team member (preferably someone working on a related task)
