### PR TITLE
Fixed sound 3D settings on poster A target

### DIFF
--- a/Assets/Prefabs/Props/Key Props/Tape 1/PosterA Variant.prefab
+++ b/Assets/Prefabs/Props/Key Props/Tape 1/PosterA Variant.prefab
@@ -57,6 +57,10 @@ PrefabInstance:
       value: 542.47
       objectReference: {fileID: 0}
     - target: {fileID: 1135362213715467583, guid: 2e1828c6120bf8b4facd22f188fa08d2, type: 3}
+      propertyPath: dialogueAudio
+      value: 
+      objectReference: {fileID: 8300000, guid: f6c3b0be6e584e04b9d8b8b9d9c4bec4, type: 3}
+    - target: {fileID: 1135362213715467583, guid: 2e1828c6120bf8b4facd22f188fa08d2, type: 3}
       propertyPath: wallMountable
       value: 1
       objectReference: {fileID: 0}
@@ -378,9 +382,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1
   MinDistance: 3
-  MaxDistance: 500
+  MaxDistance: 70
   Pan2D: 0
-  rolloffMode: 0
+  rolloffMode: 2
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -388,23 +392,68 @@ AudioSource:
     serializedVersion: 2
     m_Curve:
     - serializedVersion: 3
-      time: 0
+      time: 0.02
       value: 1
-      inSlope: 0
-      outSlope: 0
+      inSlope: -50.01992
+      outSlope: -50.01992
       tangentMode: 0
       weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.04
+      value: 0.5
+      inSlope: -12.50498
+      outSlope: -12.50498
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.08
+      value: 0.25
+      inSlope: -3.126245
+      outSlope: -3.126245
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.16
+      value: 0.125
+      inSlope: -0.78156126
+      outSlope: -0.78156126
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.32
+      value: 0.051605225
+      inSlope: -0.19539031
+      outSlope: -0.19539031
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.63630736
+      value: 0.014907837
+      inSlope: -0.04884758
+      outSlope: -0.04884758
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
     - serializedVersion: 3
       time: 1
       value: 0
-      inSlope: 0
-      outSlope: 0
+      inSlope: -0.020007975
+      outSlope: -0.020007975
       tangentMode: 0
       weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
+      inWeight: 0
+      outWeight: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4

--- a/Assets/Prefabs/Props/Key Props/Tape 2/BandShirt Variant.prefab
+++ b/Assets/Prefabs/Props/Key Props/Tape 2/BandShirt Variant.prefab
@@ -209,9 +209,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1
   MinDistance: 3
-  MaxDistance: 500
+  MaxDistance: 70
   Pan2D: 0
-  rolloffMode: 0
+  rolloffMode: 2
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -219,23 +219,59 @@ AudioSource:
     serializedVersion: 2
     m_Curve:
     - serializedVersion: 3
-      time: 0
+      time: 0.042857144
       value: 1
-      inSlope: 0
-      outSlope: 0
+      inSlope: -23.342697
+      outSlope: -23.342697
       tangentMode: 0
       weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.08571429
+      value: 0.5
+      inSlope: -5.8356743
+      outSlope: -5.8356743
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.17142858
+      value: 0.25
+      inSlope: -1.4589186
+      outSlope: -1.4589186
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.34285715
+      value: 0.10321045
+      inSlope: -0.36472964
+      outSlope: -0.36472964
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.6820217
+      value: 0.018936157
+      inSlope: -0.09118241
+      outSlope: -0.09118241
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
     - serializedVersion: 3
       time: 1
       value: 0
-      inSlope: 0
-      outSlope: 0
+      inSlope: -0.042874273
+      outSlope: -0.042874273
       tangentMode: 0
       weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
+      inWeight: 0
+      outWeight: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
On beta if you listen closely you can hear the poster puzzle target glitching even when you are in the reality room. I changed the 3D sound decay curve to make sure you can't hear it.

### Type of change
<!---  Choose one or more of the following -->
<!---  - Bug fix (non-breaking change which fixes an issue) -->
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->
Bug fix 

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Insert the tape 1 into the TV and stand near the bed in reality. You shouldn't hear glitch. Go to memory scene. You should hear glitch.

# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
