### PR TITLE
Reset hold area rotation after exiting inspection mode

### DIFF
--- a/Assets/Scripts/Object Interaction/Inspection.cs
+++ b/Assets/Scripts/Object Interaction/Inspection.cs
@@ -7,18 +7,20 @@ public class Inspection : MonoBehaviour
     public GameObject holdArea;
     public AudioClipScriptableObject objectAudioInfo;
 
-
     private Camera cam;
     private Vector3 screenspaceCenter;
     private Vector3 localSidePosition;
 
     private Bounds heldObjBounds;
 
+    private Quaternion originalRotation;
+
     private void Awake()
     {
         cam = Camera.main;
         screenspaceCenter = new Vector3(Screen.width / 2, Screen.height / 2, 1.5f);
         localSidePosition = holdArea.transform.localPosition;
+        originalRotation = holdArea.transform.rotation;
     }
 
     public bool InspectIsValid()
@@ -44,7 +46,7 @@ public class Inspection : MonoBehaviour
         } else
         {
             newPosition = localSidePosition;
-
+            holdArea.transform.rotation = originalRotation;
             newLayer = "Default";
         }
 

--- a/Assets/Scripts/Object Interaction/PickupInteractable.cs
+++ b/Assets/Scripts/Object Interaction/PickupInteractable.cs
@@ -160,6 +160,7 @@ public class PickupInteractable : Interactable
     {
         originalObjScale = transform.localScale;
         transform.localScale = transform.localScale / 2;
+        // TODO: figure out how to make all held objects a consistent size
     }
     #endregion
 }


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->
See title

### Type of change
<!---  Choose one or more of the following -->
<!---  - Bug fix (non-breaking change which fixes an issue) -->
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->
- Bug fix

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Inspect an object, rotate it a bunch - when you exit inspection mode, the object's rotation looks like when you first picked it up

# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
