### PR TITLE
Disable tv mode in pause

### DIFF
--- a/Assets/Input System/Input Manager.cs
+++ b/Assets/Input System/Input Manager.cs
@@ -158,6 +158,8 @@ public class InputManager : MonoBehaviour
         EventSystem.current.SetSelectedGameObject(resumeButton);
 
         playerInputActions.Player.Disable();
+        playerInputActions.Television.Disable();
+        playerInputActions.UI.Pause.Disable(); 
 
         hud.SetActive(false);
 
@@ -166,15 +168,23 @@ public class InputManager : MonoBehaviour
 
     public void ResumeGame()
     {
+        Debug.Log("input manager resume");
+        playerInputActions.Television.Enable();
         pauseMenu.SetActive(false); 
         Time.timeScale = 1;
         gamePaused = false;
         playerInputActions.Player.Enable();
+        playerInputActions.UI.Pause.Enable(); 
         EventSystem.current.SetSelectedGameObject(oldSelected);
 
         hud.SetActive(true);
 
         OnGameResumed?.Invoke();
+    }
+
+    public bool isPaused()
+    {
+        return gamePaused;
     }
     #endregion
 

--- a/Assets/Prefabs/Props/Key Props/Tape 2/Band Picture Frame Variant.prefab
+++ b/Assets/Prefabs/Props/Key Props/Tape 2/Band Picture Frame Variant.prefab
@@ -70,72 +70,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
   m_PrefabInstance: {fileID: 1710728930503517573}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2303089718373462978
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 3361149822212860292}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.016751198
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.014886632
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.000000042104368
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 423144471960478181, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_Convex
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-      propertyPath: m_Name
-      value: Picture_frame_farewell_texture (update)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
---- !u!4 &1764441941723599913 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3a97a88bc1672954a8496834924708c6, type: 3}
-  m_PrefabInstance: {fileID: 2303089718373462978}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3405340666061986370
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -370,7 +304,7 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 140346988126114387, guid: 2e1828c6120bf8b4facd22f188fa08d2, type: 3}
       insertIndex: 0
-      addedObject: {fileID: 1764441941723599913}
+      addedObject: {fileID: 7664540820403273711}
     - targetCorrespondingSourceObject: {fileID: 7422350813914525900, guid: 2e1828c6120bf8b4facd22f188fa08d2, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1168406594713027182}
@@ -393,4 +327,98 @@ Transform:
 Transform:
   m_CorrespondingSourceObject: {fileID: 7422350813914525900, guid: 2e1828c6120bf8b4facd22f188fa08d2, type: 3}
   m_PrefabInstance: {fileID: 3411387807905676247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7914885279056615428
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3361149822212860292}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.016751198
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.878
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.000000042104368
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -5689148468934132828, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -5161123478224407820, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 423144471960478181, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Name
+      value: Picture_frame_farewell_texture
+      objectReference: {fileID: 0}
+    - target: {fileID: 2390968118795756768, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3853773005751419327, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8119357084933166448, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8426419570346336316, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Convex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852682127461523498, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7bf9c719935a2c54db3fb6744757e847, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+--- !u!4 &7664540820403273711 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a7dd679fef6135246a8514f505f78ba6, type: 3}
+  m_PrefabInstance: {fileID: 7914885279056615428}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/ChangeCameraPosition.cs
+++ b/Assets/Scripts/ChangeCameraPosition.cs
@@ -18,14 +18,6 @@ public class ChangeCameraPosition : MonoBehaviour
     void Start()
     {        
         _videoControls = FindObjectOfType<VideoControls>();
-        InputManager.OnGamePaused += PauseGame;
-        InputManager.OnGameResumed += ResumeGame;
-    }
-
-    private void OnDestroy()
-    {
-        InputManager.OnGamePaused -= PauseGame;
-        InputManager.OnGameResumed -= ResumeGame;
     }
 
     /*
@@ -62,30 +54,17 @@ public class ChangeCameraPosition : MonoBehaviour
     {
         _videoControls.Pause(); // pause video in case playing
 
-        _originalCamera.gameObject.SetActive(true);
-        tvViewCamera.gameObject.SetActive(false);
+        if (_originalCamera != null)
+        {
+            _originalCamera.gameObject.SetActive(true);
+            tvViewCamera.gameObject.SetActive(false);
 
-        HUD.GetComponent<Canvas>().worldCamera = _originalCamera.transform.Find("UI Camera").GetComponent<Camera>();
+            HUD.GetComponent<Canvas>().worldCamera = _originalCamera.transform.Find("UI Camera").GetComponent<Camera>();
+        }
 
         _televisionCanvas.SetActive(false);
         
         // Turn Player model back on
         _playerModel.SetActive(true);
-    }
-
-    void PauseGame()
-    {
-        if (_televisionCanvas.activeSelf)
-        {
-            _televisionCanvas.GetComponentInChildren<UnityEngine.EventSystems.EventSystem>().enabled = false;
-        }
-    }
-
-    void ResumeGame()
-    {
-        if (_televisionCanvas.activeSelf)
-        {
-            _televisionCanvas.GetComponentInChildren<UnityEngine.EventSystems.EventSystem>().enabled = true;
-        }
     }
 }

--- a/Assets/Scripts/UI/SliderController.cs
+++ b/Assets/Scripts/UI/SliderController.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System;
 
-public class CameraSlider : MonoBehaviour
+public class SliderController : MonoBehaviour
 {
     [SerializeField] private float maxSliderAmount = 2.0f;
 
@@ -25,5 +25,5 @@ public class CameraSlider : MonoBehaviour
         float changeValue = localValue - 1.0f;
         InputManager inputManager = FindObjectOfType<InputManager>();
         inputManager.changeCameraSpeed(1.0f + (float) Math.Tan(changeValue * 0.5f));
-    }
+    }      
 }


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Disabled TV mode and pausing again in pause menu.
- Fixed the change camera position bug of getting null game object error when try to pause in TV mode.
- Still one weird bug that needs to click T twice for exiting TV mode after resume from pause menu in TV mode. Will fix later.

### Type of change
<!---  Choose one or more of the following -->
 - Bug fix (non-breaking change which fixes an issue)
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Try different combinations of opening TV mode and pause mode. See if TV mode and pausing again is disabled in pause menu.

# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [ ] I have requested a review from at least one (1) team member (preferably someone working on a related task)
