### PR TITLE
Exit tv bug in pause

### DIFF
--- a/Assets/Input System/Input Manager.cs
+++ b/Assets/Input System/Input Manager.cs
@@ -158,7 +158,6 @@ public class InputManager : MonoBehaviour
         EventSystem.current.SetSelectedGameObject(resumeButton);
 
         playerInputActions.Player.Disable();
-        playerInputActions.Television.Disable();
         playerInputActions.UI.Pause.Disable(); 
 
         hud.SetActive(false);
@@ -168,12 +167,13 @@ public class InputManager : MonoBehaviour
 
     public void ResumeGame()
     {
-        Debug.Log("input manager resume");
-        playerInputActions.Television.Enable();
-        pauseMenu.SetActive(false); 
-        Time.timeScale = 1;
         gamePaused = false;
-        playerInputActions.Player.Enable();
+        Time.timeScale = 1;
+        pauseMenu.SetActive(false); 
+        if (!inTVMode)
+        {
+            playerInputActions.Player.Enable();
+        }
         playerInputActions.UI.Pause.Enable(); 
         EventSystem.current.SetSelectedGameObject(oldSelected);
 
@@ -252,7 +252,7 @@ public class InputManager : MonoBehaviour
     #region Television Toggle
     private void OpenTelevision(InputAction.CallbackContext obj)
     {
-        Debug.Log("Opening TV button pressed");
+        Debug.Log("Opening TV");
         playerInputActions.Player.Disable();
         playerInputActions.Television.Enable();
 
@@ -264,6 +264,7 @@ public class InputManager : MonoBehaviour
 
     public void CloseTelevision(InputAction.CallbackContext obj)
     {
+        Debug.Log("Close TV");
         inTVMode = false;
 
         playerInputActions.Television.Disable();

--- a/Assets/Scripts/ChangeCameraPosition.cs
+++ b/Assets/Scripts/ChangeCameraPosition.cs
@@ -54,16 +54,6 @@ public class ChangeCameraPosition : MonoBehaviour
     {
         _videoControls.Pause(); // pause video in case playing
 
-        Debug.Log("to player view");
-
-        // if (_originalCamera != null)
-        // {
-        //     _originalCamera.gameObject.SetActive(true);
-        //     tvViewCamera.gameObject.SetActive(false);
-
-        //     HUD.GetComponent<Canvas>().worldCamera = _originalCamera.transform.Find("UI Camera").GetComponent<Camera>();
-        // }
-
         _originalCamera.gameObject.SetActive(true);
         tvViewCamera.gameObject.SetActive(false);
 

--- a/Assets/Scripts/ChangeCameraPosition.cs
+++ b/Assets/Scripts/ChangeCameraPosition.cs
@@ -54,13 +54,20 @@ public class ChangeCameraPosition : MonoBehaviour
     {
         _videoControls.Pause(); // pause video in case playing
 
-        if (_originalCamera != null)
-        {
-            _originalCamera.gameObject.SetActive(true);
-            tvViewCamera.gameObject.SetActive(false);
+        Debug.Log("to player view");
 
-            HUD.GetComponent<Canvas>().worldCamera = _originalCamera.transform.Find("UI Camera").GetComponent<Camera>();
-        }
+        // if (_originalCamera != null)
+        // {
+        //     _originalCamera.gameObject.SetActive(true);
+        //     tvViewCamera.gameObject.SetActive(false);
+
+        //     HUD.GetComponent<Canvas>().worldCamera = _originalCamera.transform.Find("UI Camera").GetComponent<Camera>();
+        // }
+
+        _originalCamera.gameObject.SetActive(true);
+        tvViewCamera.gameObject.SetActive(false);
+
+        HUD.GetComponent<Canvas>().worldCamera = _originalCamera.transform.Find("UI Camera").GetComponent<Camera>();
 
         _televisionCanvas.SetActive(false);
         


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Previous bug: open TV mode -> open pause menu -> click resume -> all the TV buttons are working, but when try to exit TV mode, only works on second click

### Type of change
<!---  Choose one or more of the following -->
- Bug fix (non-breaking change which fixes an issue)
<!---  - New feature (non-breaking change which adds functionality) -->
<!---  - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!---  - Documentation update -->
<!---  - Integrating assets -->

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Check if the previous bug still exist.

# Checklists
## Integration Checklist
- [x] I have attached this PR to the relevant Trello card
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file

## Review Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [ ] I have requested a review from at least one (1) team member (preferably someone working on a related task)
