### PR TITLE
Poster reach limit

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -306,7 +306,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1066319376766034934
 Transform:
   m_ObjectHideFlags: 0
@@ -1039,7 +1039,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 738a21b01cc02714db306bc4ebfad0c5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxPlayerReach: 10
+  maxPlayerReach: 8
   _crossHairDisplay: {fileID: 0}
   _defaultCrosshair: {fileID: 21300000, guid: caa749efeba804f428f6745c380f84bc, type: 3}
   _objectDetected: {fileID: 21300000, guid: 25e2f5b86fc7eb44bb9b41599cdb09dd, type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -11249,13 +11249,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1906215052}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0.37567112, z: -0, w: 0.92675304}
-  m_LocalPosition: {x: -4.54, y: 0, z: 3.77}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5, y: 0, z: 4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 395161055}
-  m_LocalEulerAnglesHint: {x: 0, y: -44.132, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1924094092
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11944,6 +11944,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 697516125670228093, guid: 3c62d3de721f74c408418603d93d771c, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 697516125670228093, guid: 3c62d3de721f74c408418603d93d771c, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: bbd060cd6e916e840a194ccb33c8893c, type: 2}
     - target: {fileID: 2195079554922053423, guid: 3c62d3de721f74c408418603d93d771c, type: 3}
       propertyPath: m_LocalPosition.x
       value: -4.15
@@ -13635,6 +13643,10 @@ PrefabInstance:
       propertyPath: effects
       value: 
       objectReference: {fileID: 542954244}
+    - target: {fileID: 2030963388574207995, guid: c1047ff49c7f8a44ba57c555856614e0, type: 3}
+      propertyPath: spawnpoint
+      value: 
+      objectReference: {fileID: 1906215053}
     - target: {fileID: 2030963388574207995, guid: c1047ff49c7f8a44ba57c555856614e0, type: 3}
       propertyPath: cameraAnimator
       value: 

--- a/Assets/Scripts/Object Interaction/PickUpInteractor.cs
+++ b/Assets/Scripts/Object Interaction/PickUpInteractor.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-// using Unity.PlasticSCM.Editor.WebApi;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using TMPro;
-using UnityEngine.Scripting.APIUpdating;
-using UnityEngine.UI;
 
 /// <summary>
 /// Handles the communication between the player and the object. Specifically manages what object is held (`HeldObj`)

--- a/Assets/Scripts/Object Interaction/PickupInteractable.cs
+++ b/Assets/Scripts/Object Interaction/PickupInteractable.cs
@@ -81,6 +81,11 @@ public class PickupInteractable : Interactable
         }
     }
 
+    public void MovePlacementGuideToScene(Vector3 newSpawnPoint)
+    {
+        placementGuide.transform.position = newSpawnPoint + new Vector3(0, 0, 1);
+    }
+
     public void TransformPlacementGuide(RaycastHit hit)
     {
         if (!placementGuide.activeSelf) return;

--- a/Assets/Scripts/SceneManagement.cs
+++ b/Assets/Scripts/SceneManagement.cs
@@ -15,6 +15,8 @@ public class SceneManagement : MonoBehaviour
     public GameObject enterMemoryButton;
     public Animator cameraAnimator;
 
+    public Transform spawnpoint;
+
     public AudioClip memoryEnterSfx;
     public AudioClip memoryExitSfx;
     public GameObject mainAudioSource;
@@ -81,8 +83,7 @@ public class SceneManagement : MonoBehaviour
         _originalPlayerPos = player.transform.position;
         _originalPlayerRot = player.transform.rotation;
 
-        player.transform.position = new Vector3(-5.03f, 50f, 4f);
-        player.transform.rotation = new Quaternion(0, 0, 0, 0);
+        MovePlayerToScene(spawnpoint.position, spawnpoint.rotation);
     }
 
     public void ExitMemoryScene()
@@ -92,7 +93,7 @@ public class SceneManagement : MonoBehaviour
         audioSource.pitch = 3;
         GetComponent<AudioSource>().PlayOneShot(memoryExitSfx);
 
-        player.transform.SetPositionAndRotation(_originalPlayerPos, _originalPlayerRot);
+        MovePlayerToScene(_originalPlayerPos, _originalPlayerRot);
 
         _interactionCue.SetInteractionCue(InteractionCueType.ExitMemory);
 
@@ -103,4 +104,16 @@ public class SceneManagement : MonoBehaviour
         Vector3 cameraRotationAtTelevision = new Vector3(0, 160, 0);
         player.transform.rotation = Quaternion.Euler(cameraRotationAtTelevision);
     } 
+
+    private void MovePlayerToScene(Vector3 newSpawnPointPos, Quaternion newRotation)
+    {
+        player.transform.SetPositionAndRotation(newSpawnPointPos, newRotation);
+
+        // if is holding object, move to scene
+        PickUpInteractor pickUpInteractor = player.GetComponent<PickUpInteractor>();
+        if (pickUpInteractor.isHoldingObj())
+        {
+            pickUpInteractor.HeldObj.GetComponent<PickupInteractable>().MovePlacementGuideToScene(newSpawnPointPos);
+        }
+    }
 }


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->
Meant to resolve Issue #184 
- When switching to the memory scene, teleport the placement guide to the memory scene too. This way objects don't teleport back to the tv.
- Shortened player reach, so that they cannot reach across the room without moving

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Insert tape, pick up poster, enter memory scene, and without moving your camera try to place the poster on the wall. It should fall to the floor.

# Checklists
## Integration Checklist
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file
- [x] My changes were integrated into the main scene

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
