### PR TITLE
Fixed bug where Inspect Obj cue was shown with no obj held

### DIFF
--- a/Assets/Scripts/Input System/Input Manager.cs
+++ b/Assets/Scripts/Input System/Input Manager.cs
@@ -326,7 +326,6 @@ public class InputManager : MonoBehaviour
     public void EnterMemoryScene()
     {
         Debug.Log("Entering memory scene, from input manager");
-        wasInspectEnabled = true;
         CloseTelevision(new InputAction.CallbackContext());
         playerInputActions.Player.OpenTV.Disable();
         playerInputActions.Memory.Enable();


### PR DESCRIPTION
<!--- Make sure the PR title makes it easy to identify which Trello card it is linked to -->

# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
For issue #214 

# How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
- Enter memory with no item held
- Enter memory with item held
- Pickup and drop item
Inspect cue should only show when item is held.

# Checklists
## Integration Checklist
- [x] **I have not touched the main Room scene**
- [x] My changes generate no new errors
- [x] Any dependencies have already gone live on the `main` branch or were merged in separately
- [x] Any modifications to prefabs have been applied to the original prefab file
- [x] My changes were integrated into the main scene

## Review Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have kept my test scenes/assets in a folder called "To Be Deleted," and will remove them before merging
- [x] I have requested a review from at least one (1) team member (preferably someone working on a related task)
